### PR TITLE
Performance Improvement on Dense Shapes 

### DIFF
--- a/src/main/scala/spatialspark/join/BroadcastSpatialJoin.scala
+++ b/src/main/scala/spatialspark/join/BroadcastSpatialJoin.scala
@@ -16,8 +16,8 @@
 
 package spatialspark.join
 
-import com.vividsolutions.jts.geom.Geometry
 import com.vividsolutions.jts.index.strtree.STRtree
+import com.vividsolutions.jts.geom.{Geometry, GeometryFactory}
 import spatialspark.operator.SpatialOperator
 import SpatialOperator.SpatialOperator
 import org.apache.spark.SparkContext
@@ -27,6 +27,17 @@ import org.apache.spark.rdd.RDD
 
 object BroadcastSpatialJoin {
 
+  def wider_search(rtree: => Broadcast[STRtree], leftId: Long, geom: Geometry, radius: Double): Array[AnyRef] = {
+    val geometryFactory = new GeometryFactory()
+    val geom_ex = geom.getEnvelopeInternal
+    geom_ex.expandBy(radius)
+    val new_envelope = geometryFactory.toGeometry(geom_ex).getEnvelopeInternal
+    val candidates2 = rtree.value.query(new_envelope).toArray
+    if (candidates2.size != 0 || radius>10){
+      candidates2
+    }else
+      wider_search(rtree,leftId,geom,radius*20)
+  }
 
   def queryRtree(rtree: => Broadcast[STRtree], leftId: Long, geom: Geometry, predicate: SpatialOperator,
                  radius: Double): Array[(Long, Long)] = {
@@ -49,12 +60,23 @@ object BroadcastSpatialJoin {
       candidates.filter { case (id_, geom_) => geom.overlaps(geom_.asInstanceOf[Geometry]) }
         .map { case (id_, geom_) => (leftId, id_.asInstanceOf[Long]) }
     } else if (predicate == SpatialOperator.NearestD) {
-      if (candidates.isEmpty)
-        return Array.empty[(Long, Long)]
-      val nearestItem = candidates.map {
-        case (id_, geom_) => (id_.asInstanceOf[Long], geom_.asInstanceOf[Geometry].distance(geom))
-      }.reduce((a, b) => if (a._2 < b._2) a else b)
-      Array((leftId, nearestItem._1))
+      if (candidates.size ==0) {
+        //making a bigger query
+        val candidates2 = wider_search(rtree,leftId,geom,radius)
+        if (candidates2.size==0){
+          return Array.empty[(Long, Long)]
+        }
+        val nearestItem = candidates2.map {
+          case (id_, geom_) => (id_.asInstanceOf[Long], geom_.asInstanceOf[Geometry].distance(geom))
+        }.reduce((a, b) => if (a._2 < b._2) a else b)
+        Array((leftId, nearestItem._1))
+
+      }else {
+        val nearestItem = candidates.map {
+          case (id_, geom_) => (id_.asInstanceOf[Long], geom_.asInstanceOf[Geometry].distance(geom))
+        }.reduce((a, b) => if (a._2 < b._2) a else b)
+        Array((leftId, nearestItem._1))
+      }
     } else {
       Array.empty[(Long, Long)]
     }


### PR DESCRIPTION
Performance Improve on Dense Shapes or when Index returns a lot of candidates.

On my Use cases I get like 200M rows and I have 20000 shapes. 
The NearestD takes forever because the query on the STRtree returns the hole 20 000

With this if the user starts with a small radius let's say 0.0001 if the index does not returning anything then we expand the point and try the query again. 
